### PR TITLE
More TypeScript types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   ],
   plugins: ['@typescript-eslint', 'jest', 'import'],
   rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
     'no-console': 'warn',
     eqeqeq: 'error', // strict equals
   },

--- a/src/dataSources.ts
+++ b/src/dataSources.ts
@@ -1,10 +1,7 @@
 import MoviesAPI from './MoviesAPI'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const dataSources = (): any => {
-  return {
-    moviesAPI: new MoviesAPI(),
-  }
-}
+const dataSources = () => ({
+  moviesAPI: new MoviesAPI(),
+})
 
 export default dataSources

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,32 +1,24 @@
-import {
-  Movie,
-  CreateMovieResponse,
-  NewMovie,
-} from './types'
+import { ResolversContext, NewMovieInput, CreateMovieResponse } from './types'
+import { IResolvers } from 'apollo-server'
 
-const resolvers = {
+const resolvers: IResolvers = {
   Query: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     movies: (
       _: void,
       __: void,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { dataSources }: { dataSources: any }
-    ): Movie[] => dataSources.moviesAPI.getMovies(),
+      { dataSources }: ResolversContext
+    ) => dataSources.moviesAPI.getMovies(),
   },
   Mutation: {
     createMovie: (
       _: void,
-      { newMovie }: { newMovie: NewMovie },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { dataSources }: { dataSources: any }
+      { newMovie }: NewMovieInput,
+      { dataSources }: ResolversContext
     ): CreateMovieResponse => {
       const movies = dataSources.moviesAPI.createMovie(
         newMovie
       )
-      return {
-        movies,
-      }
+      return { movies }
     },
   },
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import MoviesAPI from "./MoviesAPI";
+
 export interface Movie {
   id: string
   title: string
@@ -7,6 +9,22 @@ export interface NewMovie {
   title: string
 }
 
+export interface NewMovieInput {
+  newMovie: NewMovie
+}
+
 export interface CreateMovieResponse {
-  movies: Movie[]
+  movies: Promise<Movie[]>
+}
+
+export interface GraphQLCustomDataSources {
+  moviesAPI: MoviesAPI;
+}
+
+export interface GraphQLCustomContext {
+  credentials: null;
+}
+
+export interface ResolversContext extends GraphQLCustomContext {
+  dataSources: GraphQLCustomDataSources;
 }


### PR DESCRIPTION
Just read your post at https://dev.to/learnitmyway/testing-apollo-server-with-typescript-2d8 and since I recently started working on a similar code myself, I got curious. 

This is how I've set it up to get types in the resolvers. I don't use the _explicit-function-return-type_ rule, since I find it unnecessary and I couldn't get it to work here.

Of course, feel free to ignore this PR 😉